### PR TITLE
Fixed auth request in check_jenkins_job_extended.pl

### DIFF
--- a/check_jenkins_job_extended.pl
+++ b/check_jenkins_job_extended.pl
@@ -179,6 +179,9 @@ if( $numFailedBuilds > 0 ) {
       $firstFailedBuildURL = $jobStatusUrlPrefix . "/" . $firstFailedBuildId;
       $firstFailedBuildApiURL = $firstFailedBuildURL . "/api/json";
       $req3 = HTTP::Request->new( GET => $firstFailedBuildApiURL );
+      if ( !$userName eq '' ) {
+        $req3->authorization_basic( $userName, $password);
+      }
       $res3 = $ua3->request($req3);
     }
 


### PR DESCRIPTION
Fixed auth section when checking first failed build after last successfull build
