### PR TITLE
Please check 2 new optional settings

### DIFF
--- a/check_jenkins_cron.pl
+++ b/check_jenkins_cron.pl
@@ -259,7 +259,7 @@ sub response($$) {
 
 sub usage {
     print << "EOF";
-usage: $0 -j <job> -l <url> -w <threshold> -c <threshold> [-f] [-u username -p password] [-v]
+usage: $0 -j <job> -l <url> -w <threshold> -c <threshold> [-f] [-u username -p password] [-a count] [-s] [-t seconds] [-v]
     
     Required arguments
         -j <job>        : Jenkins job name


### PR DESCRIPTION
Hello,
I added 3 optional settings:
-t timeout when connecting to API
-s generate WARNING when job was never started at all
-c count of failed builds since last stable build

Thank you
