### PR TITLE
Logic change for less surprising behavior and default parameter fix

### DIFF
--- a/check_jenkins_cron.pl
+++ b/check_jenkins_cron.pl
@@ -26,7 +26,7 @@ my $password;
 my $thresh_warn;
 my $thresh_crit;
 my $alert_on_fail;
-my $alert_on_lastx_fail;
+my $alert_on_lastx_fail = 0;
 my $alert_on_nostart;
 my $debug = 0;
 my $timeout = 0;

--- a/check_jenkins_cron.pl
+++ b/check_jenkins_cron.pl
@@ -94,7 +94,7 @@ sub main {
             ($dur_sec, $dur_human) = calcdur(int($ls_data->{timestamp} / 1000));
             if ($dur_sec >= $thresh_crit && $thresh_crit) {
                 response("CRITICAL", "'$jobname' has not run successfully for $dur_human. " . ($ls_not_lb ? "Runs since failed. " : "No runs since. ") . $lb_data->{url} );
-            } elsif ($dur_sec >= $thresh_warn && $thresh_warn && $ls_not_lb) {
+            } elsif ($dur_sec >= $thresh_warn && $thresh_warn) {
                 response("WARNING", "'$jobname' has not run successfully for $dur_human. " . ($ls_not_lb ? "Runs since failed. " : "No runs since. ") . $lb_data->{url} );
             }
             

--- a/check_jenkins_cron.pl
+++ b/check_jenkins_cron.pl
@@ -95,9 +95,7 @@ sub main {
             if ($dur_sec >= $thresh_crit && $thresh_crit) {
                 response("CRITICAL", "'$jobname' has not run successfully for $dur_human. " . ($ls_not_lb ? "Runs since failed. " : "No runs since. ") . $lb_data->{url} );
             } elsif ($dur_sec >= $thresh_warn && $thresh_warn && $ls_not_lb) {
-                response("CRITICAL", "'$jobname' has not run successfully for $dur_human. Runs since failed. " . $lb_data->{url});
-            } elsif ($dur_sec >= $thresh_warn && $thresh_warn) {
-                response("WARNING", "'$jobname' has not run successfully for $dur_human. No runs since. " . $lb_data->{url})
+                response("WARNING", "'$jobname' has not run successfully for $dur_human. " . ($ls_not_lb ? "Runs since failed. " : "No runs since. ") . $lb_data->{url} );
             }
             
             if ($ls_data->{number} != $lb_data->{number} && $alert_on_fail and $alert_on_lastx_fail <= 1) {


### PR DESCRIPTION
We found it surprising that in some cases exceeding the warn threshold would report as CRITICAL. Change this case to report as WARNING but also report the runs since state (similar to first CRITICAL check). If we want to keep this behaviour, it should maybe be an extra flag.

Also fixed an issue where if the `-a` option is not provided it would complain about an uninitialised variable in comparison.