### PR TITLE
Fetch the status of the last completed build

### DIFF
--- a/check_jenkins_cron.pl
+++ b/check_jenkins_cron.pl
@@ -81,7 +81,7 @@ sub main {
         &usage;
     }
     
-    my ($lb_status, $lb_resp, $lb_data) = apireq('lastBuild', $timeout);
+    my ($lb_status, $lb_resp, $lb_data) = apireq('lastCompletedBuild', $timeout);
     my ($ls_status, $ls_resp, $ls_data) = apireq('lastStableBuild', $timeout);
     my $ls_not_lb = 0;
     


### PR DESCRIPTION
Previously the last build was used which includes builds that are still running.
Thus the check failed when passed "-f" while a build was running.